### PR TITLE
use parse_known_args instead parse_args

### DIFF
--- a/pytorch/language-modeling/local/trainer_customer/arguments.py
+++ b/pytorch/language-modeling/local/trainer_customer/arguments.py
@@ -29,4 +29,4 @@ def setup_args():
                         default=os.getenv('LOCAL_RANK', -1),
                         help="Local rank. Necessary for using the torch.distributed.launch utility")
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/pytorch/language-modeling/netmind/trainer_customer/arguments.py
+++ b/pytorch/language-modeling/netmind/trainer_customer/arguments.py
@@ -29,4 +29,4 @@ def setup_args():
                         default=os.getenv('LOCAL_RANK', -1),
                         help="Local rank. Necessary for using the torch.distributed.launch utility")
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/pytorch/resnet/local/argument.py
+++ b/pytorch/resnet/local/argument.py
@@ -38,4 +38,4 @@ def setup_args():
                         default=os.getenv('LOCAL_RANK', -1),
                         help="Local rank. Necessary for using the torch.distributed.launch utility")
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/pytorch/resnet/netmind/argument.py
+++ b/pytorch/resnet/netmind/argument.py
@@ -38,4 +38,4 @@ def setup_args():
                         default=os.getenv('LOCAL_RANK', -1),
                         help="Local rank. Necessary for using the torch.distributed.launch utility")
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/local/image-classification-custom/arguments.py
+++ b/tensorflow/local/image-classification-custom/arguments.py
@@ -26,4 +26,4 @@ def setup_args():
     parser.add_argument('--seed', default=1, type=int, required=False, help='training seed')
     parser.add_argument("--warmup_steps", default=5000, type=float)
     
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/local/image-classification/arguments.py
+++ b/tensorflow/local/image-classification/arguments.py
@@ -26,4 +26,4 @@ def setup_args():
     parser.add_argument('--seed', default=1, type=int, required=False, help='training seed')
     parser.add_argument("--warmup_steps", default=5000, type=float)
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/local/language-modeling/arguments.py
+++ b/tensorflow/local/language-modeling/arguments.py
@@ -19,4 +19,4 @@ def setup_args():
     parser.add_argument("--save_steps", default=100, type=int)
     parser.add_argument('--per_device_train_batch_size', default=8, type=int, required=False,
                         help='training batchsize')
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/netmind/image-classification-custom/arguments.py
+++ b/tensorflow/netmind/image-classification-custom/arguments.py
@@ -25,4 +25,4 @@ def setup_args():
     parser.add_argument('--learning_rate', default=0.1, type=float, required=False, help='initial learning rate')
     parser.add_argument('--num_train_epochs', default=90, type=int, required=False, help='training epoch num')
     parser.add_argument('--seed', default=1, type=int, required=False, help='training seed')
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/netmind/image-classification/arguments.py
+++ b/tensorflow/netmind/image-classification/arguments.py
@@ -26,4 +26,4 @@ def setup_args():
     parser.add_argument('--seed', default=1, type=int, required=False, help='training seed')
     parser.add_argument("--warmup_steps", default=5000, type=float)
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]

--- a/tensorflow/netmind/language-modeling/arguments.py
+++ b/tensorflow/netmind/language-modeling/arguments.py
@@ -19,4 +19,4 @@ def setup_args():
     parser.add_argument("--save_steps", default=100, type=int)
     parser.add_argument('--per_device_train_batch_size', default=8, type=int, required=False,
                         help='training batchsize')
-    return parser.parse_args()
+    return parser.parse_known_args()[0]


### PR DESCRIPTION
parse_known_args允许传递arguments之外的参数，而程序不会因为识别不到而报错，而且该方式也兼容codelab(https://www.codenong.com/50763033/)